### PR TITLE
remove json helper code and use standard everywhere

### DIFF
--- a/sijax/core.py
+++ b/sijax/core.py
@@ -13,8 +13,8 @@ from __future__ import (absolute_import, unicode_literals)
     :license: BSD, see LICENSE.txt for more details.
 """
 
+import json
 from builtins import str
-from .helper import json
 from .response.base import BaseResponse
 from .exception import SijaxError
 

--- a/sijax/helper.py
+++ b/sijax/helper.py
@@ -17,28 +17,6 @@ from builtins import (next, open)
 from .exception import SijaxError
 
 
-# Try to load the best json implementation,
-# If json support is not available, we'll add
-# an object that raises a RuntimeError when used
-json = None
-try:
-    import simplejson as json
-except ImportError:
-    try:
-        import json
-    except ImportError:
-        try:
-            # Google Appengine offers simplejson via django
-            from django.utils import simplejson as json
-        except ImportError:
-            pass
-if json is None:
-    class _JSON(object):
-        def __getattr__(self, name):
-            raise RuntimeError('You need a JSON library to use Sijax!')
-    json = _JSON()
-
-
 def init_static_path(static_path):
     """Mirrors the important static files from the whole Sijax package
     into a directory of your choice.

--- a/sijax/plugin/upload/__init__.py
+++ b/sijax/plugin/upload/__init__.py
@@ -15,7 +15,7 @@ from __future__ import (absolute_import, unicode_literals)
 """
 
 
-from ...helper import json
+import json
 from ...response import StreamingIframeResponse
 
 # Parameters with these names are passed to the client side (JS)

--- a/sijax/response/base.py
+++ b/sijax/response/base.py
@@ -14,8 +14,8 @@ from __future__ import (absolute_import, unicode_literals)
 """
 
 
+import json
 from builtins import (object, str)
-from ..helper import json
 from ..exception import SijaxError
 from types import GeneratorType
 

--- a/tests/sijax_tests.py
+++ b/tests/sijax_tests.py
@@ -6,6 +6,7 @@ import os
 import unittest
 import tempfile
 import shutil
+import json
 from contextlib import contextmanager
 
 from builtins import (range, str, next, open)
@@ -149,7 +150,6 @@ class SijaxMainTestCase(unittest.TestCase):
         # streaming functions return generators instead..
         self.assertTrue(isinstance(response, str))
 
-        from sijax.helper import json
         try:
             commands = json.loads(response)
         except:
@@ -206,7 +206,6 @@ class SijaxMainTestCase(unittest.TestCase):
             pass
 
     def test_process_request_calls_invalid_request_event_for_invalid_requests(self):
-        from sijax.helper import json
 
         # An invalid request is a request for a function that's not registered,
         # meaning the request is invalid as far as sijax is concerned
@@ -235,7 +234,6 @@ class SijaxMainTestCase(unittest.TestCase):
 
     def test_process_request_calls_invalid_call_event_for_invalid_calls(self):
         from types import FunctionType
-        from sijax.helper import json
 
         # An invalid call is a call to a function that appears valid.
         # The function is registered (known), but calling fails, because


### PR DESCRIPTION
Since Python < 2.6 is not supported any longer, we can rely on the standard library package `json`.